### PR TITLE
chore: Fixup pre-commits

### DIFF
--- a/examples/simple-nodejs/main.tf
+++ b/examples/simple-nodejs/main.tf
@@ -20,8 +20,8 @@ module "lambda" {
   output_path = "${path.module}/source.zip"
 
   build_triggers = {
-    requirements = "${base64sha256(file("${path.module}/source/package-lock.json"))}"
-    execute      = "${base64sha256(file("${path.module}/npm.sh"))}"
+    requirements = base64sha256(file("${path.module}/source/package-lock.json"))
+    execute      = base64sha256(file("${path.module}/npm.sh"))
   }
   build_command = "${path.module}/npm.sh ${path.module}/source"
 

--- a/examples/simple-py/main.tf
+++ b/examples/simple-py/main.tf
@@ -20,8 +20,8 @@ module "lambda" {
   output_path = "${path.module}/source.zip"
 
   build_triggers = {
-    requirements = "${base64sha256(file("${path.module}/source/requirements.txt"))}"
-    execute      = "${base64sha256(file("${path.module}/pip.sh"))}"
+    requirements = base64sha256(file("${path.module}/source/requirements.txt"))
+    execute      = base64sha256(file("${path.module}/pip.sh"))
   }
   build_command = "${path.module}/pip.sh ${path.module}/source"
 


### PR DESCRIPTION
The pre-commit workflow is failing on new PRs due to deprecation warnings found by tflint.
This PR addresses it.